### PR TITLE
Add support for STARTTLS SMTP relay

### DIFF
--- a/crates/authifier/src/config/email_verification.rs
+++ b/crates/authifier/src/config/email_verification.rs
@@ -28,6 +28,9 @@ pub struct SMTPSettings {
 
     /// Whether to use TLS
     pub use_tls: Option<bool>,
+
+    /// Whether to use STARTTLS
+    pub use_starttls: Option<bool>,
 }
 
 /// Email template
@@ -103,7 +106,13 @@ pub enum EmailVerificationConfig {
 impl SMTPSettings {
     /// Create SMTP transport
     pub fn create_transport(&self) -> SmtpTransport {
-        let relay = SmtpTransport::relay(&self.host).unwrap();
+        let relay = if let Some(true) = self.use_starttls {
+            SmtpTransport::starttls_relay(&self.host).unwrap()
+        } else {
+            SmtpTransport::relay(&self.host).unwrap()
+        };
+
+        
         let relay = if let Some(port) = self.port {
             relay.port(port.try_into().unwrap())
         } else {

--- a/crates/rocket_authifier/src/test.rs
+++ b/crates/rocket_authifier/src/test.rs
@@ -26,6 +26,7 @@ pub async fn test_smtp_config() -> Config {
                 username: "noreply@example.com".into(),
                 password: "password_insecure".into(),
                 use_tls: Some(false),
+                use_starttls: Some(false),
             },
             expiry: Default::default(),
             templates: Templates {


### PR DESCRIPTION
This adds another optional boolean configuration value `use_starttls` to relay emails via STARTTLS.

Fixes https://github.com/authifier/authifier/issues/66